### PR TITLE
Feature/settings form

### DIFF
--- a/src/components/FormPopUp.tsx
+++ b/src/components/FormPopUp.tsx
@@ -1,0 +1,43 @@
+import { useState, type PropsWithChildren, type ReactNode } from "react";
+
+type Props = {
+    button: ReactNode;
+}
+
+export default function FormPopUp({ children, button }: PropsWithChildren<Props>) {
+    const [showForm, setShowForm] = useState(false);
+
+    return (
+        <>
+            {showForm && (
+                <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 w-11/12 max-w-150 overflow-y-auto">
+                    <div className="bg-base-100 rounded-lg shadow-xl p-6 md:p-8">
+                        
+                        {children}
+
+                        <div className="flex gap-3 mt-1">
+                            <button
+                                type="button"
+                                onClick={() => setShowForm(false)}
+                                className="btn btn-ghost flex-1"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {showForm && (
+                <div
+                    className="fixed inset-0 backdrop-blur-sm bg-black/50 z-40"
+                    onClick={() => setShowForm(false)}
+                />
+            )}
+
+            <div onClick={() => setShowForm(true)}>
+                {button}
+            </div>
+        </>
+    )
+}

--- a/src/components/dashboard/CreateButton.tsx
+++ b/src/components/dashboard/CreateButton.tsx
@@ -9,3 +9,14 @@ export default function CreateButton({onClick}: {onClick: () => void}) {
         </button>
     );
 }
+
+export function CreateButtonWithOutClick() {
+    return (
+        <button
+            className="fixed bottom-0 right-0 mb-5 me-2 z-60 btn btn-ghost btn-circle">
+            <svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" fill="currentColor" className="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+                <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3z" />
+            </svg>
+        </button>
+    );
+}

--- a/src/components/dashboard/StorageCard.tsx
+++ b/src/components/dashboard/StorageCard.tsx
@@ -1,5 +1,7 @@
 import { useAuth, useStorages } from "shelflife-react-hooks";
 import type { Storage } from "../../types/Storage";
+import FormPopUp from "../FormPopUp";
+import SettingsForm from "../storage/SettingsFrom";
 
 export default function StorageCard({ storage }: { storage: Storage; }) {
     const { user } = useAuth();
@@ -18,24 +20,30 @@ export default function StorageCard({ storage }: { storage: Storage; }) {
     return (
         <div className="card card-bordered bg-base-300 w-full">
             <div className="card-body">
-                <div className="flex items-start justify-between">
-                    <div>
-                        <h2 className="card-title text-2xl">{storage.name}</h2>
-                        {
-                            storage.owner.id !== user?.id && (
-                                <p>{"Owned by: " + storage.owner.username}</p>
-                            )
-                        }
+
+                <FormPopUp button={
+                    // Check if the user is the owner of the storage, if not, don't show the settings button
+                    <div className="flex items-start justify-between">
+                        <div>
+                            <h2 className="card-title text-2xl">{storage.name}</h2>
+                            {
+                                storage.owner.id !== user?.id && (
+                                    <p>{"Owned by: " + storage.owner.username}</p>
+                                )
+                            }
+                        </div>
+                        <a className="btn btn-ghost btn-sm btn-circle">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-gear-fill" viewBox="0 0 16 16">
+                                <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
+                            </svg>
+                        </a>
                     </div>
-                    <a className="btn btn-ghost btn-sm btn-circle">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-gear-fill" viewBox="0 0 16 16">
-                            <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
-                        </svg>
-                    </a>
-                </div>
+                }>
+                    <SettingsForm storage={storage}/>
+                </FormPopUp>
                 <div className="grid grid-cols-3 gap-2 mt-4">
                     <a className="btn btn-sm sm:btn-md btn-success">Members</a>
-                    <a className="btn btn-sm sm:btn-md btn-primary">View Items</a>
+                    <a className="btn btn-sm sm:btn-md btn-primary">Items</a>
                     <button onClick={handleDelete} className="btn btn-sm sm:btn-md btn-error">
                         {deleteButtonValue}
                     </button>

--- a/src/components/dashboard/products/CreateProductForm.tsx
+++ b/src/components/dashboard/products/CreateProductForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState } from "react";
 import CreateButton from "../CreateButton";
 import { useProducts } from "shelflife-react-hooks";
 
@@ -25,7 +25,7 @@ export default function CreateProductForm() {
                 name,
                 category,
                 barcode: barcode || undefined,
-                expirationDaysDelta: expiration,
+                expirationDaysDelta: expirationDaysDelta,
             });
             fetchProducts();
             setShowForm(false);

--- a/src/components/dashboard/products/ProductTable.tsx
+++ b/src/components/dashboard/products/ProductTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, useReactTable, type ColumnDef, type SortingState } from "@tanstack/react-table";
+import { flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, useReactTable, type ColumnDef, type Row, type SortingState } from "@tanstack/react-table";
 import { useAuth, useProducts, type Product } from "shelflife-react-hooks";
 
 

--- a/src/components/storage/NewForm.tsx
+++ b/src/components/storage/NewForm.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { useStorages } from "shelflife-react-hooks";
+
+type Props = {}
+
+export default function CreateStorageForm({ }: Props) {
+    const { createStorage, fetchStorages } = useStorages();
+     const [newStorageName, setNewStorageName] = useState("");
+    
+        const handleSubmit = async (e: React.SubmitEvent) => {
+            e.preventDefault();
+            if (!newStorageName) return;
+    
+            await createStorage({ name: newStorageName });
+            fetchStorages();
+            setNewStorageName(""); 
+        };
+
+    return (
+        <>
+            <div className="flex justify-between items-center mb-6">
+                <h2 className="text-2xl font-bold">Add New Storage</h2>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="form-control">
+                    <div className="inline-grid *:[grid-area:1/1]">
+                        <div className={`status ${newStorageName ? 'status-success' : 'status-error'} animate-ping me-2`}></div>
+                        <div className={`status ${newStorageName ? 'status-success' : 'status-error'} me-2`}></div>
+                    </div>
+                    <label className="label">
+                        <span className="label-text font-semibold me-2">Storage Name</span>
+                    </label>
+                    <input
+                        type="text"
+                        maxLength={40}
+                        name="name"
+                        placeholder="e.g., Kitchen Pantry"
+                        className="input input-bordered"
+                        value={newStorageName}
+                        onChange={(e) => setNewStorageName(e.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className="flex gap-3 mt-6">
+                    <button
+                        type="submit"
+                        disabled={!newStorageName}
+                        className={`btn flex-1 ${newStorageName ? 'btn-info' : 'btn-disabled'}`}
+                    >
+                        Create Storage
+                    </button>
+
+                </div>
+            </form>
+        </>
+    )
+}

--- a/src/components/storage/NewForm.tsx
+++ b/src/components/storage/NewForm.tsx
@@ -5,16 +5,16 @@ type Props = {}
 
 export default function CreateStorageForm({ }: Props) {
     const { createStorage, fetchStorages } = useStorages();
-     const [newStorageName, setNewStorageName] = useState("");
-    
-        const handleSubmit = async (e: React.SubmitEvent) => {
-            e.preventDefault();
-            if (!newStorageName) return;
-    
-            await createStorage({ name: newStorageName });
-            fetchStorages();
-            setNewStorageName(""); 
-        };
+    const [newStorageName, setNewStorageName] = useState("");
+
+    const handleSubmit = async (e: React.SubmitEvent) => {
+        e.preventDefault();
+        if (!newStorageName) return;
+
+        await createStorage({ name: newStorageName });
+        fetchStorages();
+        setNewStorageName("");
+    };
 
     return (
         <>

--- a/src/components/storage/SettingsFrom.tsx
+++ b/src/components/storage/SettingsFrom.tsx
@@ -1,0 +1,11 @@
+type Props ={
+
+}
+
+export default function SettingsForm({}: Props) {
+    return (
+        <div>
+            <h1>Settings</h1>
+        </div>
+    )
+}

--- a/src/components/storage/SettingsFrom.tsx
+++ b/src/components/storage/SettingsFrom.tsx
@@ -1,11 +1,62 @@
-type Props ={
+import { useState } from "react";
+import { useStorages, type Storage } from "shelflife-react-hooks"
 
+type Props ={
+    storage: Storage
 }
 
-export default function SettingsForm({}: Props) {
+export default function SettingsForm({ storage }: Props) {
+    const { changeStorageName, fetchStorages} = useStorages();
+    const [newName, setNewName] = useState<string>(storage.name);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (newName !== storage.name) {
+            await changeStorageName(storage.id, {
+                name: newName
+            });
+            fetchStorages();
+        }
+    };
+
     return (
-        <div>
-            <h1>Settings</h1>
-        </div>
+         <>
+            <div className="flex justify-between items-center mb-6">
+                <h2 className="text-2xl font-bold">Settings for {storage.name}</h2>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="form-control">
+                    <div className="inline-grid *:[grid-area:1/1]">
+                        <div className={`status ${newName ? 'status-success' : 'status-error'} animate-ping me-2`}></div>
+                        <div className={`status ${newName ? 'status-success' : 'status-error'} me-2`}></div>
+                    </div>
+                    <label className="label">
+                        <span className="label-text font-semibold me-2">Storage Name</span>
+                    </label>
+                    <input
+                        type="text"
+                        maxLength={40}
+                        name="name"
+                        placeholder="e.g., Kitchen Pantry"
+                        className="input input-bordered"
+                        value={newName}
+                        onChange={(e) => setNewName(e.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className="flex gap-3 mt-6">
+                    <button
+                        type="submit"
+                        disabled={!newName}
+                        className={`btn flex-1 ${newName ? 'btn-info' : 'btn-disabled'}`}
+                    >
+                        Save Changes
+                    </button>
+
+                </div>
+            </form>
+        </>
     )
 }

--- a/src/pages/dashboard/Storages.tsx
+++ b/src/pages/dashboard/Storages.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import StorageCard from "../../components/dashboard/StorageCard";
-import CreateButton from "../../components/dashboard/CreateButton";
+import { CreateButtonWithOutClick } from "../../components/dashboard/CreateButton";
 import { useStorages } from "shelflife-react-hooks";
 import FormPopUp from "../../components/FormPopUp";
 import CreateStorageForm from "../../components/storage/NewForm";
@@ -8,14 +8,13 @@ import CreateStorageForm from "../../components/storage/NewForm";
 export default function Storages() {
     const { storages, fetchStorages } = useStorages();
 
-
     useEffect(() => {
         fetchStorages();
     }, []);
 
     return (
         <>
-            <div className="p-8 pb-32 text-center">
+            <div className="p-8 text-center">
                 <h1 className="text-3xl font-bold mb-4">Storages</h1>
                 <p className="text-gray-600 mb-8">Manage your storages here</p>
 
@@ -32,7 +31,7 @@ export default function Storages() {
                 )}
             </div>
 
-            <FormPopUp button={<CreateButton  onClick={() => {}}/>} >
+            <FormPopUp button={<CreateButtonWithOutClick />} >
                 <CreateStorageForm />
             </FormPopUp>
         </>

--- a/src/pages/dashboard/Storages.tsx
+++ b/src/pages/dashboard/Storages.tsx
@@ -2,22 +2,12 @@ import { useEffect, useState } from "react";
 import StorageCard from "../../components/dashboard/StorageCard";
 import CreateButton from "../../components/dashboard/CreateButton";
 import { useStorages } from "shelflife-react-hooks";
+import FormPopUp from "../../components/FormPopUp";
+import CreateStorageForm from "../../components/storage/NewForm";
 
 export default function Storages() {
-    const { storages, fetchStorages, createStorage } = useStorages();
+    const { storages, fetchStorages } = useStorages();
 
-    const [showForm, setShowForm] = useState(false);
-    const [newStorageName, setNewStorageName] = useState("");
-
-    const handleSubmit = async (e: React.SubmitEvent) => {
-        e.preventDefault();
-        if (!newStorageName) return;
-
-        await createStorage({ name: newStorageName });
-        fetchStorages();
-        setNewStorageName("");
-        setShowForm(false);
-    };
 
     useEffect(() => {
         fetchStorages();
@@ -42,63 +32,9 @@ export default function Storages() {
                 )}
             </div>
 
-            {showForm && (
-                <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 w-11/12 max-w-150 overflow-y-auto">
-                    <div className="bg-base-100 rounded-lg shadow-xl p-6 md:p-8">
-                        <div className="flex justify-between items-center mb-6">
-                            <h2 className="text-2xl font-bold">Add New Storage</h2>
-                        </div>
-
-                        <form onSubmit={handleSubmit} className="space-y-4">
-                            <div className="form-control">
-                                <div className="inline-grid *:[grid-area:1/1]">
-                                    <div className={`status ${newStorageName ? 'status-success' : 'status-error'} animate-ping me-2`}></div>
-                                    <div className={`status ${newStorageName ? 'status-success' : 'status-error'} me-2`}></div>
-                                </div>
-                                <label className="label">
-                                    <span className="label-text font-semibold me-2">Storage Name</span>
-                                </label>
-                                <input
-                                    type="text"
-                                    maxLength={40}
-                                    name="name"
-                                    placeholder="e.g., Kitchen Pantry"
-                                    className="input input-bordered"
-                                    value={newStorageName}
-                                    onChange={(e) => setNewStorageName(e.target.value)}
-                                    required
-                                />
-                            </div>
-
-                            <div className="flex gap-3 mt-6">
-                                <button
-                                    type="submit"
-                                    disabled={!newStorageName}
-                                    className={`btn flex-1 ${newStorageName ? 'btn-info' : 'btn-disabled'}`}
-                                >
-                                    Create Storage
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => setShowForm(false)}
-                                    className="btn btn-ghost flex-1"
-                                >
-                                    Cancel
-                                </button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            )}
-
-            {showForm && (
-                <div
-                    className="fixed inset-0 backdrop-blur-sm bg-black/50 z-40"
-                    onClick={() => setShowForm(false)}
-                />
-            )}
-
-            <CreateButton onClick={() => setShowForm(true)} />
+            <FormPopUp button={<CreateButton  onClick={() => {}}/>} >
+                <CreateStorageForm />
+            </FormPopUp>
         </>
     )
 }


### PR DESCRIPTION
This pull request introduces a reusable modal form component and refactors storage management UI to use it, improving code organization and user experience. It also adds a settings form for editing storage names and simplifies the logic for creating new storages. The most important changes are grouped below:

**Modal Form Component and Usage**

* Added a new `FormPopUp` component to provide a reusable modal form with backdrop and cancel functionality.
* Refactored the `Storages` dashboard page to use `FormPopUp` for creating new storages, replacing inline modal logic and state management. [[1]](diffhunk://#diff-4b551bf832f7082fce90b15a8b76227498966bc31c40e1c7ff80f852ed902f45L1-R17) [[2]](diffhunk://#diff-4b551bf832f7082fce90b15a8b76227498966bc31c40e1c7ff80f852ed902f45L45-R36)
* Updated `StorageCard` to use `FormPopUp` for displaying storage settings, allowing users to edit storage names in a modal. [[1]](diffhunk://#diff-7e6cba206806d77e307190f661a8be870ebf88e9c8be0e5fdefbfe3128a9011fR3-R4) [[2]](diffhunk://#diff-7e6cba206806d77e307190f661a8be870ebf88e9c8be0e5fdefbfe3128a9011fR23-R25) [[3]](diffhunk://#diff-7e6cba206806d77e307190f661a8be870ebf88e9c8be0e5fdefbfe3128a9011fR41-R46)

**Storage Forms**

* Added `CreateStorageForm` component for creating new storages, encapsulating the form logic and UI.
* Added `SettingsForm` component for editing storage names, used within the modal in `StorageCard`.

**UI and Minor Improvements**

* Introduced `CreateButtonWithOutClick` for use with modal triggers.
* Minor UI tweaks, such as renaming the "View Items" button to "Items" in `StorageCard`.

These changes collectively improve modularity, reusability, and clarity in the storage management UI.